### PR TITLE
fixes #352 isOptionsHash - TypeError

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,7 +15,7 @@ var utils = module.exports = {
 
   isOptionsHash: function(o) {
     return isPlainObject(o) && ['api_key', 'idempotency_key', 'stripe_account'].some(function(key) {
-      return o.hasOwnProperty(key);
+      return hasOwn.call(o, key);
     });
   },
 


### PR DESCRIPTION
Fixes utils.isOptionsHash() TypeError: o.hasOwnProperty is not a function.

```
TypeError: o.hasOwnProperty is not a function
    at ./node_modules/stripe/lib/utils.js:19:16
    at Array.some (native)
    at Object.isOptionsHash (./node_modules/stripe/lib/utils.js:18:81)
    at Object.getDataFromArgs (./node_modules/stripe/lib/utils.js:59:44)
    at Object.<anonymous> (./node_modules/stripe/lib/StripeMethod.js:75:31)
```